### PR TITLE
Fix uv dev dependencies warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
   "pytest>=8.2,<9.0",
   "pytest-asyncio>=0.23,<1.0",
   "httpx>=0.27,<1.0",


### PR DESCRIPTION
Fixes uv deprecation warning by replacing `tool.uv.dev-dependencies` with `dependency-groups.dev` in `pyproject.toml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f649f4e-7188-4b33-8516-d8ed1ed89494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f649f4e-7188-4b33-8516-d8ed1ed89494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>